### PR TITLE
Fix tweet feed not deleting tweets that exceed the memory limit

### DIFF
--- a/template_static/lib/tweets.js
+++ b/template_static/lib/tweets.js
@@ -118,7 +118,7 @@ block.fn.tweets = function(config) {
         $list.prepend($item);
 
         // remove stale tweets
-        if ($list.children().size() > options.memory) {
+        if ($list.children().length > options.memory) {
             $list.children().last().remove();
         }
     });


### PR DESCRIPTION
Tweet feed would go on forever and slow down the site immensely.