### PR TITLE
Fixed unwanted gaps in rolling chart bug

### DIFF
--- a/template_static/lib/charts.js
+++ b/template_static/lib/charts.js
@@ -70,7 +70,7 @@ block.fn.rolling_chart = function(config) {
                     data[k] = data[k].slice(1);
                 }
 
-                // insert value
+                // insert value or gap (in case of null)
                 data[k].push(message.values[k]);
             }
 

--- a/template_static/lib/charts.js
+++ b/template_static/lib/charts.js
@@ -70,8 +70,8 @@ block.fn.rolling_chart = function(config) {
                     data[k] = data[k].slice(1);
                 }
 
-                // insert value or gap
-                data[k].push(message.values[k] || null);
+                // insert value
+                data[k].push(message.values[k]);
             }
 
             // update HTML


### PR DESCRIPTION
In JavaScript `0 || null` results in `null`, which meant any attempts to plot the integer zero would create a gap in the graph.
A graph with gaps can still be plotted by providing `null` as value to plot (or `None` if your working in Python).