### PR TITLE
Stop persistent requests from blocking a server shutdown

### DIFF
--- a/eca/httpd.py
+++ b/eca/httpd.py
@@ -203,6 +203,10 @@ class HTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     HTTP Server with path/method registration functionality to allow simple
     configuration of served content.
     """
+    
+    # Don't keep running requests from blocking the server shutdown
+    daemon_threads = True
+    
     def __init__(self, server_address, RequestHandlerClass=HTTPRequestHandler):
         self.handlers = []
         self.filters = []


### PR DESCRIPTION
The original error keyboardinterrupt traceback will still show, but the program will exit normally.

From my limited testing this does not seem to cause any unwanted side-effects, but it is a good idea to test with some other implementations.